### PR TITLE
Feat: 액세스 토큰 재발급 기능

### DIFF
--- a/src/components/diary/list/DiaryCard.tsx
+++ b/src/components/diary/list/DiaryCard.tsx
@@ -11,30 +11,18 @@ import React from 'react';
 import {Animated, Image, ImageBackground, Text, View} from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import {DiaryCardMenu} from './DiaryCardMenu';
+import {DiaryDetail} from '@src/types/diary';
 
 interface DiaryCardProps {
-  diaryId: number;
-  title: string;
-  period: string;
-  location: string;
-  feeling: string;
-  imageUrl: string;
-  content: string;
+  diary: DiaryDetail;
 }
 
-export const DiaryCard = ({
-  diaryId,
-  title,
-  period,
-  location,
-  feeling,
-  imageUrl,
-  content,
-}: DiaryCardProps) => {
+export const DiaryCard = ({diary}: DiaryCardProps) => {
   const {interpolate, isTail, flipCard} = useCardFlipAnimation();
   const editor = useEditorBridge({
     avoidIosKeyboard: true,
-    initialContent: content,
+    initialContent:
+      diary.diaryDayContentResponses.diaryDayContentDetail[0].content,
     editable: false,
     bridgeExtensions: [
       ...TenTapStartKit,
@@ -62,16 +50,24 @@ export const DiaryCard = ({
                 style={tw`h-[1.1875rem] w-4`}
                 source={require('@src/assets/diary/location-active.png')}
               />
-              <Text style={tw`text-gray-500`}>{location}</Text>
+              <Text style={tw`text-gray-500`}>
+                {diary.diaryDayContentResponses.diaryDayContentDetail[0].place}
+              </Text>
             </View>
-            <DiaryCardMenu diaryId={diaryId} />
+            <DiaryCardMenu diary={diary} />
           </View>
           <Image
             style={tw`mt-10 h-[4.375rem] w-14`}
-            source={FEELING_IMAGE[feeling]}
+            source={
+              FEELING_IMAGE[
+                diary.diaryDayContentResponses.diaryDayContentDetail[0]
+                  .feelingStatus
+              ]
+            }
           />
-          <Text style={tw`pt-5 text-lg font-bold`}>{title}</Text>
-          <Text style={tw`text-gray-500`}>{period}</Text>
+          <Text style={tw`pt-5 text-lg font-bold`}>{diary.title}</Text>
+          <Text
+            style={tw`text-gray-500`}>{`${new Date(diary.startDatetime).toLocaleDateString()} - ${new Date(diary.endDatetime).toLocaleDateString()}`}</Text>
           <RichText style={tw`mt-2`} editor={editor} />
         </Animated.View>
       </View>
@@ -92,7 +88,7 @@ export const DiaryCard = ({
         <ImageBackground
           style={tw`flex-1`}
           imageStyle={tw`rounded-xl`}
-          source={{uri: imageUrl}}
+          source={{uri: diary.titleImage}}
           resizeMode="cover"
         />
         <LinearGradient
@@ -100,8 +96,11 @@ export const DiaryCard = ({
           style={tw`absolute bottom-0 flex h-[11.5rem] w-full rounded-b-xl`}
         />
         <View style={tw`absolute bottom-[1.875rem] flex flex-col gap-1 px-8`}>
-          <Text style={tw`text-xl font-semibold text-white`}>{title}</Text>
-          <Text style={tw`text-sm text-white`}>{period}</Text>
+          <Text style={tw`text-xl font-semibold text-white`}>
+            {diary.title}
+          </Text>
+          <Text
+            style={tw`text-sm text-white`}>{`${new Date(diary.startDatetime).toLocaleDateString()} - ${new Date(diary.endDatetime).toLocaleDateString()}`}</Text>
         </View>
       </Animated.View>
     </View>

--- a/src/components/diary/list/DiaryCardList.tsx
+++ b/src/components/diary/list/DiaryCardList.tsx
@@ -49,24 +49,7 @@ export const DiaryCardList = ({
             y: 0,
           }}
           data={diaryList.content}
-          renderItem={({item}) => (
-            <DiaryCard
-              diaryId={item.diaryId}
-              title={item.title}
-              period={`${new Date(item.startDatetime).toLocaleDateString()} - ${new Date(item.endDatetime).toLocaleDateString()}`}
-              location={
-                item.diaryDayContentResponses.diaryDayContentDetail[0].place
-              }
-              feeling={
-                item.diaryDayContentResponses.diaryDayContentDetail[0]
-                  .feelingStatus
-              }
-              imageUrl={item.titleImage}
-              content={
-                item.diaryDayContentResponses.diaryDayContentDetail[0].content
-              }
-            />
-          )}
+          renderItem={({item}) => <DiaryCard diary={item} />}
           keyExtractor={item => item.diaryId.toString()}
         />
       )}

--- a/src/components/diary/list/DiaryCardMenu.tsx
+++ b/src/components/diary/list/DiaryCardMenu.tsx
@@ -2,18 +2,19 @@ import {useNavigation} from '@react-navigation/native';
 import {COLOR} from '@src/constants/color';
 import {useDiaryDelete} from '@src/hooks/diary/list/useDiaryDelete';
 import {tw} from '@src/libs/tailwind';
+import {DiaryDetail} from '@src/types/diary';
 import {NavigationProps} from '@src/types/navigation';
 import React, {useState} from 'react';
 import {ActivityIndicator, Image, Pressable, Text, View} from 'react-native';
 
 interface DiaryCardMenuProps {
-  diaryId: number;
+  diary: DiaryDetail;
 }
 
-export const DiaryCardMenu = ({diaryId}: DiaryCardMenuProps) => {
+export const DiaryCardMenu = ({diary}: DiaryCardMenuProps) => {
   const navigation = useNavigation<NavigationProps>();
   const [visible, setVisible] = useState(false);
-  const {isPending, handleDeleteButtonClick} = useDiaryDelete(diaryId);
+  const {isPending, handleDeleteButtonClick} = useDiaryDelete(diary.diaryId);
 
   return (
     <View style={tw`relative`}>
@@ -47,7 +48,7 @@ export const DiaryCardMenu = ({diaryId}: DiaryCardMenuProps) => {
             onTouchEnd={e => {
               e.stopPropagation();
               setVisible(false);
-              navigation.navigate('DiaryUpdate', {diaryId});
+              navigation.navigate('DiaryUpdate', {diary});
             }}>
             <Text style={tw`py-2 text-center`}>수정</Text>
           </Pressable>

--- a/src/components/diary/list/DiaryCardMenu.tsx
+++ b/src/components/diary/list/DiaryCardMenu.tsx
@@ -1,19 +1,10 @@
-import {BACKEND_URL} from '@env';
 import {useNavigation} from '@react-navigation/native';
 import {COLOR} from '@src/constants/color';
+import {useDiaryDelete} from '@src/hooks/diary/list/useDiaryDelete';
 import {tw} from '@src/libs/tailwind';
 import {NavigationProps} from '@src/types/navigation';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
 import React, {useState} from 'react';
-import {
-  ActivityIndicator,
-  Alert,
-  Image,
-  Pressable,
-  Text,
-  View,
-} from 'react-native';
-import EncryptedStorage from 'react-native-encrypted-storage';
+import {ActivityIndicator, Image, Pressable, Text, View} from 'react-native';
 
 interface DiaryCardMenuProps {
   diaryId: number;
@@ -22,44 +13,11 @@ interface DiaryCardMenuProps {
 export const DiaryCardMenu = ({diaryId}: DiaryCardMenuProps) => {
   const navigation = useNavigation<NavigationProps>();
   const [visible, setVisible] = useState(false);
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async () => {
-      const accessToken = await EncryptedStorage.getItem('access_token');
-      const response = await fetch(`${BACKEND_URL}/api/diary/${diaryId}`, {
-        method: 'DELETE',
-        headers: {
-          Cookie: `access_token=${accessToken}`,
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to delete.');
-      }
-
-      return true;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['diaryList']});
-    },
-    throwOnError: true,
-  });
-
-  const handleDeleteButtonClick = () => {
-    Alert.alert('여행일기 삭제', '정말 삭제하시겠습니까?', [
-      {text: '취소'},
-      {
-        text: '삭제',
-        onPress: () => {
-          mutation.mutate();
-        },
-      },
-    ]);
-  };
+  const {isPending, handleDeleteButtonClick} = useDiaryDelete(diaryId);
 
   return (
     <View style={tw`relative`}>
-      {mutation.isPending ? (
+      {isPending ? (
         <ActivityIndicator
           style={tw`h-8 w-8 bg-blue-100`}
           color={COLOR.PRIMARY_GREEN}

--- a/src/components/tour/TourItemMenu.tsx
+++ b/src/components/tour/TourItemMenu.tsx
@@ -1,10 +1,8 @@
-import {BACKEND_URL} from '@env';
 import {COLOR} from '@src/constants/color';
+import {useTourItemDelete} from '@src/hooks/tour/useTourItemDelete';
 import {tw} from '@src/libs/tailwind';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
 import React from 'react';
-import {ActivityIndicator, Alert, Image, Pressable, View} from 'react-native';
-import EncryptedStorage from 'react-native-encrypted-storage';
+import {ActivityIndicator, Image, Pressable, View} from 'react-native';
 
 interface TourItemMenuProps {
   planId: number;
@@ -12,47 +10,14 @@ interface TourItemMenuProps {
 }
 
 export const TourItemMenu = ({planId, planTitle}: TourItemMenuProps) => {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async () => {
-      const accessToken = await EncryptedStorage.getItem('access_token');
-      const response = await fetch(
-        `${BACKEND_URL}/api/travel/user-plan/${planId}`,
-        {
-          method: 'DELETE',
-          headers: {
-            Cookie: `access_token=${accessToken}`,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error('Failed to delete.');
-      }
-
-      return true;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['tourItemList']});
-    },
-    throwOnError: true,
-  });
-
-  const handleDeleteButtonClick = () => {
-    Alert.alert(`${planTitle} 삭제`, '정말 삭제하시겠습니까?', [
-      {text: '취소'},
-      {
-        text: 'TODO', // TODO: "삭제"
-        onPress: () => {
-          // mutation.mutate();
-        },
-      },
-    ]);
-  };
+  const {isPending, handleDeleteButtonClick} = useTourItemDelete(
+    planId,
+    planTitle,
+  );
 
   return (
     <View style={tw`relative`}>
-      {mutation.isPending ? (
+      {isPending ? (
         <ActivityIndicator style={tw`h-8 w-8`} color={COLOR.PRIMARY_GREEN} />
       ) : (
         <Pressable

--- a/src/hooks/auth/useSignIn.ts
+++ b/src/hooks/auth/useSignIn.ts
@@ -6,17 +6,14 @@ export const useSignIn = (code: string) => {
   const {isSuccess} = useQuery({
     queryKey: ['signIn', code],
     queryFn: async () => {
-      const signInResponse = await fetch(
+      const response = await fetch(
         `${BACKEND_URL}/api/auth/oauth2/login?type=kakao&redirectUrl=${KAKAO_REDIRECT_URL}&code=${code}`,
-        {
-          method: 'GET',
-          credentials: 'include',
-        },
+        {method: 'GET', credentials: 'include'},
       );
 
-      const cookies = signInResponse.headers.get('set-cookie')?.split(',');
+      const cookies = response.headers.get('set-cookie')?.split(',');
 
-      if (!signInResponse.ok || !cookies) {
+      if (!response.ok || !cookies) {
         throw new Error('Failed to sign in.');
       }
 

--- a/src/hooks/auth/useUserInfo.ts
+++ b/src/hooks/auth/useUserInfo.ts
@@ -1,33 +1,35 @@
 import {BACKEND_URL} from '@env';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
 import {User} from '@src/types/user';
 import {useQuery} from '@tanstack/react-query';
 import EncryptedStorage from 'react-native-encrypted-storage';
 
 export const useUserInfo = (enabled?: boolean) => {
-  const {data, isLoading, isError} = useQuery<User>({
+  const {data, isLoading} = useQuery<User>({
     queryKey: ['userInfo'],
     queryFn: async () => {
       const accessToken = await EncryptedStorage.getItem('access_token');
-
-      console.log('[userInfo]');
-      console.log(accessToken); // TODO
-      console.log();
-
       const userInfoResponse = await fetch(`${BACKEND_URL}/api/users/info`, {
         method: 'GET',
-        headers: {
-          Cookie: `access_token=${accessToken}`,
-          'Access-Control-Allow-Origin': '*',
-        },
+        headers: {Cookie: `access_token=${accessToken}`},
       });
+
+      if (userInfoResponse.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
+
+      if (!userInfoResponse.ok) {
+        await EncryptedStorage.clear();
+      }
 
       return await userInfoResponse.json();
     },
     staleTime: Infinity,
     gcTime: 0,
-    retry: false,
+    retry: 1,
     enabled: enabled,
   });
 
-  return {data, isLoading, isError};
+  return {data, isLoading};
 };

--- a/src/hooks/auth/useUserInfo.ts
+++ b/src/hooks/auth/useUserInfo.ts
@@ -9,21 +9,21 @@ export const useUserInfo = (enabled?: boolean) => {
     queryKey: ['userInfo'],
     queryFn: async () => {
       const accessToken = await EncryptedStorage.getItem('access_token');
-      const userInfoResponse = await fetch(`${BACKEND_URL}/api/users/info`, {
+      const response = await fetch(`${BACKEND_URL}/api/users/info`, {
         method: 'GET',
         headers: {Cookie: `access_token=${accessToken}`},
       });
 
-      if (userInfoResponse.status === 401) {
+      if (response.status === 401) {
         await getNewAccessToken();
         throw new Error('Access token has expired.');
       }
 
-      if (!userInfoResponse.ok) {
+      if (!response.ok) {
         await EncryptedStorage.clear();
       }
 
-      return await userInfoResponse.json();
+      return await response.json();
     },
     staleTime: Infinity,
     gcTime: 0,

--- a/src/hooks/auth/useUserInfo.ts
+++ b/src/hooks/auth/useUserInfo.ts
@@ -8,6 +8,11 @@ export const useUserInfo = (enabled?: boolean) => {
     queryKey: ['userInfo'],
     queryFn: async () => {
       const accessToken = await EncryptedStorage.getItem('access_token');
+
+      console.log('[userInfo]');
+      console.log(accessToken); // TODO
+      console.log();
+
       const userInfoResponse = await fetch(`${BACKEND_URL}/api/users/info`, {
         method: 'GET',
         headers: {

--- a/src/hooks/diary/list/useDiaryDelete.ts
+++ b/src/hooks/diary/list/useDiaryDelete.ts
@@ -1,0 +1,50 @@
+import {BACKEND_URL} from '@env';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {Alert} from 'react-native';
+import EncryptedStorage from 'react-native-encrypted-storage';
+
+export const useDiaryDelete = (diaryId: number) => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const accessToken = await EncryptedStorage.getItem('access_token');
+      const response = await fetch(`${BACKEND_URL}/api/diary/${diaryId}`, {
+        method: 'DELETE',
+        headers: {
+          Cookie: `access_token=${accessToken}`,
+        },
+      });
+
+      if (response.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
+
+      if (!response.ok) {
+        throw new Error('Failed to delete.');
+      }
+
+      return true;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: ['diaryList']});
+    },
+    retry: 1,
+    throwOnError: true,
+  });
+
+  const handleDeleteButtonClick = () => {
+    Alert.alert('여행일기 삭제', '정말 삭제하시겠습니까?', [
+      {text: '취소'},
+      {
+        text: '삭제',
+        onPress: () => {
+          mutation.mutate();
+        },
+      },
+    ]);
+  };
+
+  return {isPending: mutation.isPending, handleDeleteButtonClick};
+};

--- a/src/hooks/diary/list/useDiaryList.ts
+++ b/src/hooks/diary/list/useDiaryList.ts
@@ -25,8 +25,8 @@ export const useDiaryList = (page: number) => {
 
       return await response.json();
     },
-    staleTime: 600000,
-    gcTime: 1800000,
+    staleTime: 1000 * 60 * 10,
+    gcTime: 1000 * 60 * 30,
     retry: 1,
   });
 

--- a/src/hooks/diary/register/useDiaryRegister.ts
+++ b/src/hooks/diary/register/useDiaryRegister.ts
@@ -2,6 +2,7 @@ import {BACKEND_URL} from '@env';
 import {useNavigation} from '@react-navigation/native';
 import {FEELING_STATUS} from '@src/constants/feelingStatus';
 import {SANITIZE_OPTION} from '@src/constants/sanitizeOption';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
 import {Diary} from '@src/types/diary';
 import {NavigationProps} from '@src/types/navigation';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
@@ -42,6 +43,11 @@ export const useDiaryRegister = (
         body: JSON.stringify(diaryData),
       });
 
+      if (response.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
+
       if (!response.ok) {
         throw new Error('Failed to register.');
       }
@@ -52,6 +58,7 @@ export const useDiaryRegister = (
       await queryClient.invalidateQueries({queryKey: ['diaryList']});
       navigation.goBack();
     },
+    retry: 1,
     throwOnError: true,
   });
 

--- a/src/hooks/diary/update/useDiaryUpdate.ts
+++ b/src/hooks/diary/update/useDiaryUpdate.ts
@@ -2,6 +2,7 @@ import {BACKEND_URL} from '@env';
 import {useNavigation} from '@react-navigation/native';
 import {FEELING_STATUS} from '@src/constants/feelingStatus';
 import {SANITIZE_OPTION} from '@src/constants/sanitizeOption';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
 import {Diary} from '@src/types/diary';
 import {NavigationProps} from '@src/types/navigation';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
@@ -50,6 +51,11 @@ export const useDiaryUpdate = (
         body: JSON.stringify(diaryData),
       });
 
+      if (response.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
+
       if (!response.ok) {
         throw new Error('Failed to update.');
       }
@@ -60,6 +66,7 @@ export const useDiaryUpdate = (
       await queryClient.invalidateQueries({queryKey: ['diaryList']});
       navigation.goBack();
     },
+    retry: 1,
     throwOnError: true,
   });
 

--- a/src/hooks/survey/content/useSurveyContentItemList.ts
+++ b/src/hooks/survey/content/useSurveyContentItemList.ts
@@ -27,8 +27,8 @@ export const useSurveyContentItemList = (
 
       return await response.json();
     },
-    staleTime: 600000,
-    gcTime: 1800000,
+    staleTime: 1000 * 60 * 10,
+    gcTime: 1000 * 60 * 30,
     retry: 1,
   });
 

--- a/src/hooks/survey/content/useSurveyContentItemList.ts
+++ b/src/hooks/survey/content/useSurveyContentItemList.ts
@@ -1,4 +1,5 @@
 import {BACKEND_URL} from '@env';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
 import {SurveyContentList} from '@src/types/survey';
 import {useSuspenseQuery} from '@tanstack/react-query';
 import EncryptedStorage from 'react-native-encrypted-storage';
@@ -12,11 +13,13 @@ export const useSurveyContentItemList = (
       const accessToken = await EncryptedStorage.getItem('access_token');
       const response = await fetch(
         `${BACKEND_URL}/api/media?type=${contentCategory}&page=0&size=636`,
-        {
-          method: 'GET',
-          headers: {Cookie: `access_token=${accessToken}`},
-        },
+        {method: 'GET', headers: {Cookie: `access_token=${accessToken}`}},
       );
+
+      if (response.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
 
       if (!response.ok) {
         throw new Error('Failed to fetch data.');
@@ -26,7 +29,7 @@ export const useSurveyContentItemList = (
     },
     staleTime: 600000,
     gcTime: 1800000,
-    retry: false,
+    retry: 1,
   });
 
   return {surveyContentList: data};

--- a/src/hooks/survey/result/usePlanSave.ts
+++ b/src/hooks/survey/result/usePlanSave.ts
@@ -1,5 +1,6 @@
 import {BACKEND_URL} from '@env';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {useRef} from 'react';
 import EncryptedStorage from 'react-native-encrypted-storage';
@@ -22,6 +23,11 @@ export const usePlanSave = (planId: number) => {
         body: formData.toString(),
       });
 
+      if (response.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
+
       if (!response.ok) {
         throw new Error('Failed to save a course.');
       }
@@ -32,6 +38,7 @@ export const usePlanSave = (planId: number) => {
       await queryClient.invalidateQueries({queryKey: ['tourItemList']});
       bottomSheetModalRef.current?.present();
     },
+    retry: 1,
     throwOnError: true,
   });
 

--- a/src/hooks/tour/useTourItemList.tsx
+++ b/src/hooks/tour/useTourItemList.tsx
@@ -8,6 +8,11 @@ export const useTourItemList = () => {
     queryKey: ['tourItemList'],
     queryFn: async () => {
       const accessToken = await EncryptedStorage.getItem('access_token');
+
+      console.log('[tourItemList]');
+      console.log(accessToken); // TODO
+      console.log();
+
       const response = await fetch(`${BACKEND_URL}/api/travel/user-plan`, {
         method: 'GET',
         headers: {

--- a/src/hooks/tour/useTourItemList.tsx
+++ b/src/hooks/tour/useTourItemList.tsx
@@ -1,4 +1,5 @@
 import {BACKEND_URL} from '@env';
+import {getNewAccessToken} from '@src/libs/getNewAccessToken';
 import {SavedPlan} from '@src/types/plan';
 import {useSuspenseQuery} from '@tanstack/react-query';
 import EncryptedStorage from 'react-native-encrypted-storage';
@@ -10,10 +11,13 @@ export const useTourItemList = () => {
       const accessToken = await EncryptedStorage.getItem('access_token');
       const response = await fetch(`${BACKEND_URL}/api/travel/user-plan`, {
         method: 'GET',
-        headers: {
-          Cookie: `access_token=${accessToken}`,
-        },
+        headers: {Cookie: `access_token=${accessToken}`},
       });
+
+      if (response.status === 401) {
+        await getNewAccessToken();
+        throw new Error('Access token has expired.');
+      }
 
       if (!response.ok) {
         return [];
@@ -23,6 +27,7 @@ export const useTourItemList = () => {
     },
     staleTime: 1000 * 60 * 10,
     gcTime: 1000 * 60 * 30,
+    retry: 1,
   });
 
   return {tourItemList: data};

--- a/src/hooks/tour/useTourItemList.tsx
+++ b/src/hooks/tour/useTourItemList.tsx
@@ -8,11 +8,6 @@ export const useTourItemList = () => {
     queryKey: ['tourItemList'],
     queryFn: async () => {
       const accessToken = await EncryptedStorage.getItem('access_token');
-
-      console.log('[tourItemList]');
-      console.log(accessToken); // TODO
-      console.log();
-
       const response = await fetch(`${BACKEND_URL}/api/travel/user-plan`, {
         method: 'GET',
         headers: {

--- a/src/libs/getNewAccessToken.ts
+++ b/src/libs/getNewAccessToken.ts
@@ -3,17 +3,12 @@ import EncryptedStorage from 'react-native-encrypted-storage';
 
 export const getNewAccessToken = async () => {
   const refreshToken = await EncryptedStorage.getItem('refresh_token');
-  const tokenResponse = await fetch(
-    `${BACKEND_URL}/api/auth/oauth2/token/refresh`,
-    {
-      method: 'POST',
-      headers: {
-        Cookie: `refresh_token=${refreshToken}`,
-      },
-    },
-  );
+  const response = await fetch(`${BACKEND_URL}/api/auth/oauth2/token/refresh`, {
+    method: 'POST',
+    headers: {Cookie: `refresh_token=${refreshToken}`},
+  });
 
-  const cookie = tokenResponse.headers.get('set-cookie');
+  const cookie = response.headers.get('set-cookie');
 
   if (cookie) {
     const [key, value] = cookie

--- a/src/libs/getNewAccessToken.ts
+++ b/src/libs/getNewAccessToken.ts
@@ -1,0 +1,25 @@
+import {BACKEND_URL} from '@env';
+import EncryptedStorage from 'react-native-encrypted-storage';
+
+export const getNewAccessToken = async () => {
+  const refreshToken = await EncryptedStorage.getItem('refresh_token');
+  const tokenResponse = await fetch(
+    `${BACKEND_URL}/api/auth/oauth2/token/refresh`,
+    {
+      method: 'POST',
+      headers: {
+        Cookie: `refresh_token=${refreshToken}`,
+      },
+    },
+  );
+
+  const cookie = tokenResponse.headers.get('set-cookie');
+
+  if (cookie) {
+    const [key, value] = cookie
+      ?.split(';')[0]
+      .split('=')
+      .map(str => str.trim());
+    await EncryptedStorage.setItem(key, value);
+  }
+};

--- a/src/screens/MypageScreen.tsx
+++ b/src/screens/MypageScreen.tsx
@@ -14,7 +14,7 @@ export const MypageScreen = () => {
 
   const handleSignOut = async () => {
     await EncryptedStorage.clear();
-    await queryClient.invalidateQueries({queryKey: ['userInfo']});
+    queryClient.removeQueries();
     navigation.reset({index: 0, routes: [{name: 'Auth'}]});
   };
 

--- a/src/screens/auth/AuthLoadingScreen.tsx
+++ b/src/screens/auth/AuthLoadingScreen.tsx
@@ -21,7 +21,7 @@ export const AuthLoadingScreen = ({
       return;
     }
 
-    if (data) {
+    if (data?.id) {
       navigation.reset({index: 0, routes: [{name: 'BottomTabs'}]});
     }
   }, [data, isError, isSuccess, navigation]);

--- a/src/screens/auth/AuthScreen.tsx
+++ b/src/screens/auth/AuthScreen.tsx
@@ -21,7 +21,7 @@ export const AuthScreen = () => {
     if (data?.id) {
       navigation.reset({index: 0, routes: [{name: 'BottomTabs'}]});
     }
-  }, [data, isError, navigation]);
+  }, [data?.id, isError, navigation]);
 
   if (!isError && (data?.id || isLoading)) {
     return (

--- a/src/screens/auth/AuthScreen.tsx
+++ b/src/screens/auth/AuthScreen.tsx
@@ -6,24 +6,18 @@ import {NavigationProps} from '@src/types/navigation';
 import LottieView from 'lottie-react-native';
 import React, {useEffect} from 'react';
 import {ActivityIndicator, Image, Pressable, Text, View} from 'react-native';
-import EncryptedStorage from 'react-native-encrypted-storage';
 
 export const AuthScreen = () => {
   const navigation = useNavigation<NavigationProps>();
-  const {data, isLoading, isError} = useUserInfo();
+  const {data, isLoading} = useUserInfo();
 
   useEffect(() => {
-    if (isError) {
-      EncryptedStorage.clear();
-      return;
-    }
-
     if (data?.id) {
       navigation.reset({index: 0, routes: [{name: 'BottomTabs'}]});
     }
-  }, [data?.id, isError, navigation]);
+  }, [data?.id, navigation]);
 
-  if (!isError && (data?.id || isLoading)) {
+  if (data?.id || isLoading) {
     return (
       <ActivityIndicator
         style={tw`h-full bg-white`}

--- a/src/screens/diary/DiaryUpdateScreen.tsx
+++ b/src/screens/diary/DiaryUpdateScreen.tsx
@@ -1,24 +1,10 @@
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {DiaryUpdateEditor} from '@src/components/diary/update/DiaryUpdateEditor';
-import {COLOR} from '@src/constants/color';
-import {tw} from '@src/libs/tailwind';
 import {NavigationList} from '@src/types/navigation';
-import React, {Suspense} from 'react';
-import {ActivityIndicator} from 'react-native';
+import React from 'react';
 
 export const DiaryUpdateScreen = ({
   route,
 }: NativeStackScreenProps<NavigationList, 'DiaryUpdate'>) => {
-  return (
-    <Suspense
-      fallback={
-        <ActivityIndicator
-          style={tw`h-full bg-white`}
-          size={50}
-          color={COLOR.PRIMARY_GREEN}
-        />
-      }>
-      <DiaryUpdateEditor diaryId={route.params.diaryId} />
-    </Suspense>
-  );
+  return <DiaryUpdateEditor diary={route.params.diary} />;
 };

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -8,38 +8,22 @@ export interface Diary {
 }
 
 export interface DiaryDetail {
-  diaryContentResponse: {
-    diaryId: number;
-    title: string;
-    titleImage: string;
-    startDatetime: Date;
-    endDatetime: Date;
-    diaryDayContentResponses: {
-      diaryDayContentDetail: {
-        content: string;
-        feelingStatus: string;
-        diaryDayContentImages: string;
-        place: string;
-      }[];
-    };
+  diaryId: number;
+  title: string;
+  titleImage: string;
+  startDatetime: Date;
+  endDatetime: Date;
+  diaryDayContentResponses: {
+    diaryDayContentDetail: {
+      content: string;
+      feelingStatus: string;
+      contentImage: 'EXCITED' | 'NICE' | 'SOSO' | 'SAD' | 'ANGRY';
+      place: string;
+    }[];
   };
 }
 
 export interface DiaryList {
-  content: {
-    diaryId: number;
-    title: string;
-    titleImage: string;
-    startDatetime: Date;
-    endDatetime: Date;
-    diaryDayContentResponses: {
-      diaryDayContentDetail: {
-        content: string;
-        feelingStatus: string;
-        contentImage: 'EXCITED' | 'NICE' | 'SOSO' | 'SAD' | 'ANGRY';
-        place: string;
-      }[];
-    };
-  }[];
+  content: DiaryDetail[];
   page: {totalPages: number};
 }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,5 +1,6 @@
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {Plan, SavedPlan} from './plan';
+import {DiaryDetail} from './diary';
 
 export type NavigationList = {
   BottomTabs: undefined;
@@ -9,7 +10,7 @@ export type NavigationList = {
   Home: undefined;
   Diary: undefined;
   DiaryEditor: undefined;
-  DiaryUpdate: {diaryId: number};
+  DiaryUpdate: {diary: DiaryDetail};
   Mypage: undefined;
   Auth: undefined;
   AuthSignIn: undefined;


### PR DESCRIPTION
## ☑️ 개발 유형

- [x] Front-end

## ✔️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.

- [x] Refresh Token이 남아있는 상태에서 Access Token이 만료된 경우 Access Token을 재발급받는 기능 구현

  먼저 다음과 같이 Refresh Token을 통해 Access Token을 재발급받는 함수를 구현하였습니다.

  ```typescript
  import {BACKEND_URL} from '@env';
  import EncryptedStorage from 'react-native-encrypted-storage';

  export const getNewAccessToken = async () => {
    const refreshToken = await EncryptedStorage.getItem('refresh_token');
    const response = await fetch(`${BACKEND_URL}/api/auth/oauth2/token/refresh`, {
      method: 'POST',
      headers: {Cookie: `refresh_token=${refreshToken}`},
    });

    const cookie = response.headers.get('set-cookie');

    if (cookie) {
      const [key, value] = cookie
        ?.split(';')[0]
        .split('=')
        .map(str => str.trim());
      await EncryptedStorage.setItem(key, value);
    }
  };
  ```

  이후 HTTP 요청 결과로 401 응답 코드가 반환되는 경우 위에서 구현한 함수를 사용하여 Access Token을 재발급받아 다시 HTTP 요청을 
  보내도록 구현하였습니다. HTTP 요청을 다시 보낼 수 있도록 retry의 값을 1로 설정하였습니다.

  ```typescript
  import {BACKEND_URL} from '@env';
  import {getNewAccessToken} from '@src/libs/getNewAccessToken';
  import {SavedPlan} from '@src/types/plan';
  import {useSuspenseQuery} from '@tanstack/react-query';
  import EncryptedStorage from 'react-native-encrypted-storage';

  export const useTourItemList = () => {
    const {data} = useSuspenseQuery<SavedPlan[]>({
      queryKey: ['tourItemList'],
      queryFn: async () => {
        const accessToken = await EncryptedStorage.getItem('access_token');
        const response = await fetch(`${BACKEND_URL}/api/travel/user-plan`, {
          method: 'GET',
          headers: {Cookie: `access_token=${accessToken}`},
        });

        if (response.status === 401) {
          await getNewAccessToken();
          throw new Error('Access token has expired.');
        }

        if (!response.ok) {
          return [];
        }

        return await response.json();
      },
      staleTime: 1000 * 60 * 10,
      gcTime: 1000 * 60 * 30,
      retry: 1,
    });

    return {tourItemList: data};
  };
  ```

- [x] 여행일기 수정 시 일기 데이터를 서버에서 가져오지 않고 일기 목록 화면에서 가져오도록 변경

  기존에는 아래와 같이 서버에서 일기 데이터를 가져오도록 구현하였습니다.

  ```typescript
  export const DiaryUpdateEditor = ({diaryId}: DiaryUpdateEditorProps) => {
    const navigation = useNavigation<NavigationProps>();
    const {data} = useSuspenseQuery<DiaryDetail>({
      queryKey: ['diary', diaryId],
      queryFn: async () => {
        const accessToken = await EncryptedStorage.getItem('access_token');
        const response = await fetch(`${BACKEND_URL}/api/diary/${diaryId}`, {
          method: 'GET',
          headers: {Cookie: `access_token=${accessToken}`},
        });

        if (response.status === 401) {
          await getNewAccessToken();
          throw new Error('Access token has expired.');
        }

        if (!response.ok) {
          throw new Error('Failed to fetch data.');
        }

        return await response.json();
      },
      staleTime: 0,
      gcTime: 0,
      retry: 1,
    });
    const {methods, content, editor, imageMutation, handleImageUpload} =
      useDiaryEditor({
        title: data.diaryContentResponse.title,
        startDate: new Date(data.diaryContentResponse.startDatetime),
        endDate: new Date(data.diaryContentResponse.endDatetime),
        location:
          data.diaryContentResponse.diaryDayContentResponses
            .diaryDayContentDetail[0].place,
        feeling:
          FEELING_STATUS[
            data.diaryContentResponse.diaryDayContentResponses
              .diaryDayContentDetail[0].feelingStatus
          ],
        content:
          data.diaryContentResponse.diaryDayContentResponses
            .diaryDayContentDetail[0].content,
        image: data.diaryContentResponse.titleImage,
      });
    
      (...)
  ```
  
  HTTP 요청을 줄이기 위해 다음과 같이 일기 목록 화면에서 props로 데이터를 가져오도록 변경하였습니다.
  
  ```typescript
  export const DiaryUpdateEditor = ({diary}: DiaryUpdateEditorProps) => {
    const navigation = useNavigation<NavigationProps>();
    const {methods, content, editor, imageMutation, handleImageUpload} =
      useDiaryEditor({
        title: diary.title,
        startDate: new Date(diary.startDatetime),
        endDate: new Date(diary.endDatetime),
        location: diary.diaryDayContentResponses.diaryDayContentDetail[0].place,
        feeling:
          FEELING_STATUS[
            diary.diaryDayContentResponses.diaryDayContentDetail[0].feelingStatus
          ],
        content: diary.diaryDayContentResponses.diaryDayContentDetail[0].content,
        image: diary.titleImage,
      });
    
      (...)
    ```
  
## #️⃣ Related Issue

해당 Pull Request과 관련된 Issue Link를 작성해 주세요

close #35 